### PR TITLE
grabbing the GUID using command for newer unity versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ SpeechToText_AppleAPI/Xcode
 SpeechToText_AppleAPI/Assembly-CSharp.csproj
 SpeechToText_AppleAPI/SpeechToText_AppleAPI.csproj
 SpeechToText_AppleAPI/SpeechToText_AppleAPI.sln
+**/.DS_Store

--- a/SpeechToText_AppleAPI/Assets/SpeechAndText/Editor/BuildPostProcessor.cs
+++ b/SpeechToText_AppleAPI/Assets/SpeechAndText/Editor/BuildPostProcessor.cs
@@ -16,12 +16,11 @@ public class BuildPostProcessor
             PBXProject project = new PBXProject();
             project.ReadFromString(File.ReadAllText(projectPath));
 #if UNITY_2019_3_OR_NEWER
-            string targetName = project.GetUnityMainTargetGuid();
+            string targetGUID = project.GetUnityMainTargetGuid();
 #else
             string targetName = PBXProject.GetUnityTargetName();
-#endif
             string targetGUID = project.TargetGuidByName(targetName);
-
+#endif
             AddFrameworks(project, targetGUID);
             
             var plistPath = Path.Combine(path, "Info.plist");


### PR DESCRIPTION
Fixes #22 

Also added .DS_Store to ignore as the mac creates these files. 

Tested on 2019.3.13