### PR TITLE
Removing audiobus before listen

### DIFF
--- a/SpeechToText_AppleAPI/Assets/Plugins/iOS/SpeechRecorderViewController.mm
+++ b/SpeechToText_AppleAPI/Assets/Plugins/iOS/SpeechRecorderViewController.mm
@@ -75,6 +75,7 @@
 // recording
 - (void)startRecording {
     if (!audioEngine.isRunning) {
+        [inputNode removeTapOnBus:0];
         if (recognitionTask) {
             [recognitionTask cancel];
             recognitionTask = nil;


### PR DESCRIPTION
If stopping and starting listening regularly sometimes there is still an input node on the bus. So removing it at the begining on start listening.