### PR TITLE
Fix critical bug in 'SpeechToText' when trying to get the class instance

### DIFF
--- a/SpeechToText_AppleAPI/Assets/SpeechAndText/Scripts/SpeechToText.cs
+++ b/SpeechToText_AppleAPI/Assets/SpeechAndText/Scripts/SpeechToText.cs
@@ -24,7 +24,7 @@ namespace TextSpeech
         }
         public static void Init()
         {
-            if (instance != null) return;
+            if (_instance != null) return;
             GameObject obj = new GameObject();
             obj.name = "TextToSpeech";
             _instance = obj.AddComponent<SpeechToText>();


### PR DESCRIPTION
Hi!
While trying to use this library for the speech to text capabilities in Android, I've found what I think is a bug in the 'SpeechToText' class. The bug consists in referencing the class property `instance` instead of the backing field `_instance` in the 'Init()' method, so it enters a recursive chain call to the property and ends in causing a stack overflow, making the app to crash.

I've just change it to reference the class backing field`_instance`, and now it all works as expected.